### PR TITLE
Add Windows MIDI Services backend support

### DIFF
--- a/apps/desktop/electron/backends/types.ts
+++ b/apps/desktop/electron/backends/types.ts
@@ -20,14 +20,14 @@ export abstract class MidiBackend extends EventEmitter {
   abstract readonly label: string;
 
   abstract isAvailable(): Promise<boolean> | boolean;
-  abstract listPorts(): MidiPorts;
-  abstract openIn(id: string): boolean;
-  abstract openOut(id: string): boolean;
-  abstract send(portId: string, bytes: number[]): boolean;
-  abstract closeAll(): void;
+  abstract listPorts(): Promise<MidiPorts> | MidiPorts;
+  abstract openIn(id: string): Promise<boolean> | boolean;
+  abstract openOut(id: string): Promise<boolean> | boolean;
+  abstract send(portId: string, bytes: number[]): Promise<boolean> | boolean;
+  abstract closeAll(): Promise<void> | void;
 
-  dispose() {
+  async dispose() {
     this.removeAllListeners();
-    this.closeAll();
+    await Promise.resolve(this.closeAll());
   }
 }

--- a/apps/desktop/electron/backends/windowsMidiServicesBackend.ts
+++ b/apps/desktop/electron/backends/windowsMidiServicesBackend.ts
@@ -2,33 +2,368 @@ import { MidiBackend } from "./types";
 import type { BackendId } from "./types";
 import type { MidiPorts } from "../../shared/ipcTypes";
 
-// Placeholder backend for future Windows MIDI Services integration.
+type Runtime = {
+  module: unknown;
+  session: Record<string, unknown>;
+};
+
+type EndpointDescriptor = {
+  portId: string;
+  endpointId: string;
+  name: string;
+  direction: "in" | "out";
+};
+
 export class WindowsMidiServicesBackend extends MidiBackend {
   readonly id: BackendId = "windows-midi-services";
   readonly label = "Windows MIDI Services (preview)";
 
+  private runtimePromise: Promise<Runtime | null> | null = null;
+  private endpoints = new Map<string, EndpointDescriptor>();
+  private inputs = new Map<string, unknown>();
+  private outputs = new Map<string, unknown>();
+  private cachedPorts: MidiPorts = { inputs: [], outputs: [] };
+
   async isAvailable(): Promise<boolean> {
-    // Not implemented yet; return false to indicate unavailable.
-    return false;
+    const runtime = await this.getRuntime();
+    return runtime !== null;
   }
 
-  listPorts(): MidiPorts {
-    return { inputs: [], outputs: [] };
+  async listPorts(): Promise<MidiPorts> {
+    const runtime = await this.getRuntime();
+    if (!runtime) {
+      this.cachedPorts = { inputs: [], outputs: [] };
+      this.endpoints.clear();
+      return this.cachedPorts;
+    }
+    await this.refreshPorts(runtime.session);
+    return this.cachedPorts;
   }
 
-  openIn(_id: string): boolean {
-    return false;
+  async openIn(id: string): Promise<boolean> {
+    if (this.inputs.has(id)) return true;
+    const runtime = await this.getRuntime();
+    const endpoint = this.endpoints.get(id);
+    if (!runtime || !endpoint) return false;
+
+    const connection = await this.openEndpoint(runtime.session, endpoint.endpointId, "in");
+    if (!connection) return false;
+
+    this.attachInputHandler(connection, id);
+    this.inputs.set(id, connection);
+    return true;
   }
 
-  openOut(_id: string): boolean {
-    return false;
+  async openOut(id: string): Promise<boolean> {
+    if (this.outputs.has(id)) return true;
+    const runtime = await this.getRuntime();
+    const endpoint = this.endpoints.get(id);
+    if (!runtime || !endpoint) return false;
+
+    const connection = await this.openEndpoint(runtime.session, endpoint.endpointId, "out");
+    if (!connection) return false;
+
+    this.outputs.set(id, connection);
+    return true;
   }
 
-  send(_portId: string, _bytes: number[]): boolean {
-    return false;
+  async send(portId: string, bytes: number[]): Promise<boolean> {
+    const output =
+      this.outputs.get(portId) ??
+      (await this.openOut(portId).then((ok) => (ok ? this.outputs.get(portId) : undefined)));
+    if (!output) return false;
+    try {
+      this.emitToOutput(output, bytes);
+      return true;
+    } catch (err) {
+      console.error("Failed to send via Windows MIDI Services", err);
+      return false;
+    }
   }
 
-  closeAll(): void {
-    // No-op for now.
+  async closeAll(): Promise<void> {
+    this.inputs.forEach((conn) => this.closeConnection(conn));
+    this.outputs.forEach((conn) => this.closeConnection(conn));
+    this.inputs.clear();
+    this.outputs.clear();
+
+    const runtime = this.runtimePromise ? await this.runtimePromise : null;
+    const session = runtime?.session as Record<string, unknown> | undefined;
+    if (session) {
+      this.callFirst(session, ["close", "dispose", "shutdown", "disconnect"]);
+    }
   }
+
+  private async getRuntime(): Promise<Runtime | null> {
+    if (this.runtimePromise) return this.runtimePromise;
+    this.runtimePromise = this.initRuntime();
+    return this.runtimePromise;
+  }
+
+  private async initRuntime(): Promise<Runtime | null> {
+    if (process.platform !== "win32") return null;
+    try {
+      const module = await import("windows-midi-services");
+      const session = await this.createSession(module);
+      if (!session) return null;
+      return { module, session };
+    } catch (err) {
+      console.warn("Windows MIDI Services unavailable", err);
+      return null;
+    }
+  }
+
+  private async createSession(module: any): Promise<Record<string, unknown> | null> {
+    const candidates = [module?.MidiSession, module?.Session, module?.default?.MidiSession, module?.default];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      if (typeof candidate.create === "function") {
+        try {
+          const created = await candidate.create({ name: "MIDI Playground" });
+          if (created) return created as Record<string, unknown>;
+        } catch {
+          // Try the next candidate.
+        }
+      }
+      if (typeof candidate === "function") {
+        try {
+          const instance = await Promise.resolve(new candidate({ name: "MIDI Playground" }));
+          if (instance) return instance as Record<string, unknown>;
+        } catch {
+          // Keep looking.
+        }
+      }
+    }
+    if (typeof module?.createSession === "function") {
+      try {
+        const created = await module.createSession({ name: "MIDI Playground" });
+        if (created) return created as Record<string, unknown>;
+      } catch {
+        // ignore
+      }
+    }
+    return null;
+  }
+
+  private async refreshPorts(session: Record<string, unknown>) {
+    this.endpoints.clear();
+    const inputs = await this.readEndpoints(session, "in");
+    const outputs = await this.readEndpoints(session, "out");
+    this.cachedPorts = {
+      inputs: inputs.map((p) => ({ id: p.portId, name: p.name, direction: "in" })),
+      outputs: outputs.map((p) => ({ id: p.portId, name: p.name, direction: "out" }))
+    };
+    inputs.concat(outputs).forEach((endpoint) => this.endpoints.set(endpoint.portId, endpoint));
+  }
+
+  private async readEndpoints(
+    session: Record<string, unknown>,
+    direction: "in" | "out"
+  ): Promise<EndpointDescriptor[]> {
+    const methodNames =
+      direction === "in"
+        ? ["listInputs", "listInputPorts", "listInputEndpoints", "getInputs", "getInputPorts", "inputs"]
+        : ["listOutputs", "listOutputPorts", "listOutputEndpoints", "getOutputs", "getOutputPorts", "outputs"];
+
+    for (const name of methodNames) {
+      const candidate = (session as any)[name];
+      if (typeof candidate === "function") {
+        try {
+          const result = await candidate.call(session);
+          const normalized = this.normalizeEndpoints(result, direction);
+          if (normalized.length) return normalized;
+        } catch {
+          // Try the next method.
+        }
+      } else if (Array.isArray(candidate)) {
+        const normalized = this.normalizeEndpoints(candidate, direction);
+        if (normalized.length) return normalized;
+      }
+    }
+    return [];
+  }
+
+  private normalizeEndpoints(rawList: unknown, direction: "in" | "out"): EndpointDescriptor[] {
+    if (!Array.isArray(rawList)) return [];
+    return rawList
+      .map((raw, idx) => this.normalizeEndpoint(raw as Record<string, unknown>, direction, idx))
+      .filter((v): v is EndpointDescriptor => Boolean(v));
+  }
+
+  private normalizeEndpoint(
+    raw: Record<string, unknown>,
+    direction: "in" | "out",
+    idx: number
+  ): EndpointDescriptor | null {
+    const endpointId =
+      (raw?.endpointId as string | undefined) ??
+      (raw?.deviceId as string | undefined) ??
+      (raw?.id as string | undefined) ??
+      (raw?.connectionId as string | undefined) ??
+      (raw?.instanceId as string | undefined) ??
+      (raw?.uniqueId as string | undefined) ??
+      (raw?.udi as string | undefined) ??
+      `${direction}-${idx}`;
+    const name =
+      (raw?.name as string | undefined) ??
+      (raw?.displayName as string | undefined) ??
+      (raw?.endpointName as string | undefined) ??
+      (raw?.friendlyName as string | undefined) ??
+      (raw?.productName as string | undefined) ??
+      `MIDI ${direction === "in" ? "In" : "Out"} ${idx}`;
+
+    if (!endpointId) return null;
+    return {
+      portId: `${direction}:${endpointId}`,
+      endpointId,
+      name,
+      direction
+    };
+  }
+
+  private async openEndpoint(
+    session: Record<string, unknown>,
+    endpointId: string,
+    direction: "in" | "out"
+  ): Promise<unknown | null> {
+    const openMethods =
+      direction === "in"
+        ? ["openInput", "openInputPort", "openInputEndpoint", "openReceiver", "openIn"]
+        : ["openOutput", "openOutputPort", "openOutputEndpoint", "openSender", "openOut"];
+
+    for (const method of openMethods) {
+      const fn = (session as any)[method];
+      if (typeof fn !== "function") continue;
+      const opened = await this.tryOpen(fn, session, endpointId, direction);
+      if (opened) return opened;
+    }
+
+    const generic = (session as any).openEndpoint ?? (session as any).open;
+    if (typeof generic === "function") {
+      const opened = await this.tryOpen(generic, session, endpointId, direction);
+      if (opened) return opened;
+    }
+
+    return null;
+  }
+
+  private async tryOpen(
+    fn: (...args: unknown[]) => unknown,
+    ctx: Record<string, unknown>,
+    endpointId: string,
+    direction: "in" | "out"
+  ): Promise<unknown | null> {
+    try {
+      const args =
+        fn.length > 1
+          ? [endpointId, { endpointId, direction, name: "MIDI Playground" }]
+          : [endpointId];
+      const result = await Promise.resolve(fn.apply(ctx, args));
+      return result ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  private attachInputHandler(connection: any, portId: string) {
+    const emitPacket = (payload: unknown) => {
+      const bytes = this.extractBytes(payload);
+      if (bytes.length) {
+        this.emit("midi", { portId, bytes });
+      }
+    };
+
+    const listeners = [
+      { type: "onmidimessage", assign: true },
+      { type: "onmessage", assign: true },
+      { type: "ondata", assign: true }
+    ];
+
+    for (const listener of listeners) {
+      if (listener.assign && listener.type in connection) {
+        (connection as any)[listener.type] = (evt: unknown) => emitPacket((evt as any)?.data ?? evt);
+        return;
+      }
+    }
+
+    const adders: Array<[string, string]> = [
+      ["addEventListener", "midimessage"],
+      ["addEventListener", "message"],
+      ["addListener", "message"]
+    ];
+    for (const [adder, evt] of adders) {
+      if (typeof connection[adder] === "function") {
+        connection[adder](evt, (data: unknown) => emitPacket((data as any)?.data ?? data));
+        return;
+      }
+    }
+
+    if (typeof connection.on === "function") {
+      const maybeOn = connection as { on: (name: string, handler: (data: unknown) => void) => void };
+      ["midi", "message", "data"].forEach((event) => maybeOn.on(event, emitPacket));
+      return;
+    }
+
+    if (typeof connection.addListener === "function") {
+      connection.addListener("message", emitPacket);
+    }
+  }
+
+  private emitToOutput(connection: any, bytes: number[]) {
+    const buffer = Uint8Array.from(bytes);
+    const methods = ["send", "sendMessage", "sendMidiMessage", "sendPacket", "sendEvent", "sendBuffer", "write"];
+    for (const method of methods) {
+      if (typeof connection[method] === "function") {
+        connection[method](buffer);
+        return;
+      }
+    }
+    if ("output" in connection && typeof (connection as any).output?.send === "function") {
+      (connection as any).output.send(buffer);
+      return;
+    }
+    throw new Error("No send method found on Windows MIDI Services output connection");
+  }
+
+  private closeConnection(connection: any) {
+    if (!connection) return;
+    this.callFirst(connection, ["close", "disconnect", "dispose", "release", "shutdown"]);
+  }
+
+  private callFirst(target: Record<string, unknown>, methods: string[]) {
+    for (const method of methods) {
+      const fn = target[method];
+      if (typeof fn === "function") {
+        try {
+          (fn as () => unknown).call(target);
+          return;
+        } catch {
+          // move to next option
+        }
+      }
+    }
+  }
+
+  private extractBytes(payload: unknown): number[] {
+    if (!payload) return [];
+    if (payload instanceof Uint8Array) return Array.from(payload);
+    if (payload instanceof ArrayBuffer) return Array.from(new Uint8Array(payload));
+    const data =
+      (payload as any).bytes ??
+      (payload as any).data ??
+      (payload as any).message ??
+      (payload as any).packet ??
+      (payload as any).raw ??
+      null;
+    if (data instanceof Uint8Array) return Array.from(data);
+    if (data instanceof ArrayBuffer) return Array.from(new Uint8Array(data));
+    if (Array.isArray(data)) return data.map((v) => Number(v));
+    if (Array.isArray(payload as any)) return (payload as any).map((v: unknown) => Number(v));
+    return [];
+  }
+}
+
+declare module "windows-midi-services" {
+  const value: any;
+  export = value;
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -56,12 +56,12 @@ app.whenReady().then(() => {
   ipcMain.handle("midi:send", (_event, payload: MidiSendPayload) => midiBridge.send(payload));
   ipcMain.handle("midi:setRoutes", (_event, routes: RouteConfig[]) => midiBridge.setRoutes(routes));
 
-  ipcMain.handle("mapping:emit", (_event, payload: MappingEmitPayload) => {
+  ipcMain.handle("mapping:emit", async (_event, payload: MappingEmitPayload) => {
     try {
       const sends = computeMappingSends(payload.control, payload.value, payload.devices);
       for (const send of sends) {
-        midiBridge.openOut(send.portId);
-        midiBridge.send({ portId: send.portId, msg: send.msg });
+        await midiBridge.openOut(send.portId);
+        await midiBridge.send({ portId: send.portId, msg: send.msg });
       }
       return true;
     } catch (err) {
@@ -108,13 +108,13 @@ app.on("before-quit", (e) => {
       .flush()
       .catch(() => undefined)
       .finally(() => {
-        midiBridge.closeAll();
+        void midiBridge.closeAll();
         app.exit(0);
       });
     return;
   }
 
-  midiBridge.closeAll();
+  void midiBridge.closeAll();
 });
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "lint": "echo desktop lint todo",
     "test": "echo desktop test todo",
     "smoke:midi": "tsx scripts/midi-smoke.ts",
+    "smoke:winrt": "tsx scripts/winrt-smoke.ts",
     "smoke:persist": "tsx scripts/persistence-smoke.ts",
     "smoke:mapping": "tsx scripts/mapping-smoke.ts"
   },

--- a/apps/desktop/scripts/winrt-smoke.ts
+++ b/apps/desktop/scripts/winrt-smoke.ts
@@ -1,0 +1,59 @@
+import { WindowsMidiServicesBackend } from "../electron/backends/windowsMidiServicesBackend";
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  const backend = new WindowsMidiServicesBackend();
+  const available = await backend.isAvailable();
+  if (!available) {
+    console.log("Windows MIDI Services backend is not available (non-Windows platform or runtime not installed).");
+    return;
+  }
+
+  const ports = await backend.listPorts();
+  console.log("Windows MIDI Services inputs:");
+  ports.inputs.forEach((p) => console.log(`  ${p.id} :: ${p.name}`));
+  if (!ports.inputs.length) console.log("  (none)");
+
+  console.log("\nWindows MIDI Services outputs:");
+  ports.outputs.forEach((p) => console.log(`  ${p.id} :: ${p.name}`));
+  if (!ports.outputs.length) console.log("  (none)");
+
+  const firstOut = ports.outputs[0];
+  const firstIn = ports.inputs[0];
+
+  if (firstOut) {
+    console.log(`\nOpening output ${firstOut.name}...`);
+    const outOk = await backend.openOut(firstOut.id);
+    if (!outOk) {
+      console.log("Failed to open output.");
+    } else {
+      const on = await backend.send(firstOut.id, [0x90, 60, 100]);
+      await sleep(180);
+      const off = await backend.send(firstOut.id, [0x80, 60, 0]);
+      console.log(on && off ? "Sent note on/off on Windows MIDI Services backend." : "Send failed.");
+    }
+  }
+
+  if (firstIn) {
+    console.log(`\nOpening input ${firstIn.name} for 1s of monitoring...`);
+    backend.on("midi", (packet) => {
+      console.log(`MIDI packet on ${packet.portId}: [${packet.bytes.join(", ")}]`);
+    });
+    const inOk = await backend.openIn(firstIn.id);
+    if (inOk) {
+      await sleep(1000);
+    } else {
+      console.log("Failed to open input.");
+    }
+  }
+
+  await backend.closeAll();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Windows MIDI Services backend that discovers endpoints, opens ports, and emits MIDI packets via WinRT when available
- make MIDI bridge calls async-safe for backends that require asynchronous operations and update IPC handlers accordingly
- add a Windows MIDI Services smoke script and package script to exercise port open/send paths

## Testing
- pnpm -C apps/desktop smoke:mapping
- pnpm -C apps/desktop smoke:persist

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439ccf4ab8833194e8b8d4f3618404)