### PR TITLE
Add snapshot capture and recall support

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2,12 +2,20 @@ import path from "node:path";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { computeMappingSends } from "@midi-playground/core";
 import type { MidiEvent } from "@midi-playground/core";
-import type { MappingEmitPayload, MidiSendPayload, RouteConfig } from "../shared/ipcTypes";
-import type { ProjectStateV1 } from "../shared/projectTypes";
+import type {
+  MappingEmitPayload,
+  MidiSendPayload,
+  RouteConfig,
+  SnapshotCapturePayload,
+  SnapshotRecallPayload
+} from "../shared/ipcTypes";
+import type { ProjectState } from "../shared/projectTypes";
 import { MidiBridge } from "./midiBridge";
 import { ProjectStore } from "./projectStore";
+import { SnapshotService } from "./snapshotService";
 
 const midiBridge = new MidiBridge();
+const snapshotService = new SnapshotService(midiBridge);
 let projectStore: ProjectStore | null = null;
 const isDev = !app.isPackaged;
 const appDir = __dirname;
@@ -72,11 +80,14 @@ app.whenReady().then(() => {
 
   ipcMain.handle("project:load", async () => {
     if (!projectStore) return null;
-    return projectStore.load();
+    const doc = await projectStore.load();
+    snapshotService.updateDevices(doc.state.devices);
+    return doc;
   });
-  ipcMain.handle("project:setState", (_event, state: ProjectStateV1) => {
+  ipcMain.handle("project:setState", (_event, state: ProjectState) => {
     if (!projectStore) return false;
     projectStore.setState(state);
+    snapshotService.updateDevices(state.devices);
     return true;
   });
   ipcMain.handle("project:flush", async () => {
@@ -84,8 +95,11 @@ app.whenReady().then(() => {
     await projectStore.flush();
     return true;
   });
+  ipcMain.handle("snapshot:capture", (_event, payload: SnapshotCapturePayload) => snapshotService.capture(payload));
+  ipcMain.handle("snapshot:recall", (_event, payload: SnapshotRecallPayload) => snapshotService.recall(payload));
 
   midiBridge.on("midi", (evt: MidiEvent) => {
+    snapshotService.ingest(evt);
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send("midi:event", evt);
     }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,7 +1,15 @@
 import { contextBridge, ipcRenderer } from "electron";
-import type { MidiEvent } from "@midi-playground/core";
-import type { MappingEmitPayload, MidiBackendInfo, MidiPorts, MidiSendPayload, RouteConfig } from "../shared/ipcTypes";
-import type { ProjectDocV1, ProjectStateV1 } from "../shared/projectTypes";
+import type { MidiEvent, SnapshotState } from "@midi-playground/core";
+import type {
+  MappingEmitPayload,
+  MidiBackendInfo,
+  MidiPorts,
+  MidiSendPayload,
+  RouteConfig,
+  SnapshotCapturePayload,
+  SnapshotRecallPayload
+} from "../shared/ipcTypes";
+import type { ProjectDoc, ProjectState } from "../shared/projectTypes";
 
 const midiApi = {
   listPorts: (): Promise<MidiPorts> => ipcRenderer.invoke("midi:listPorts"),
@@ -12,9 +20,11 @@ const midiApi = {
   send: (payload: MidiSendPayload): Promise<boolean> => ipcRenderer.invoke("midi:send", payload),
   emitMapping: (payload: MappingEmitPayload): Promise<boolean> => ipcRenderer.invoke("mapping:emit", payload),
   setRoutes: (routes: RouteConfig[]): Promise<boolean> => ipcRenderer.invoke("midi:setRoutes", routes),
-  loadProject: (): Promise<ProjectDocV1 | null> => ipcRenderer.invoke("project:load"),
-  setProjectState: (state: ProjectStateV1): Promise<boolean> => ipcRenderer.invoke("project:setState", state),
+  loadProject: (): Promise<ProjectDoc | null> => ipcRenderer.invoke("project:load"),
+  setProjectState: (state: ProjectState): Promise<boolean> => ipcRenderer.invoke("project:setState", state),
   flushProject: (): Promise<boolean> => ipcRenderer.invoke("project:flush"),
+  captureSnapshot: (payload?: SnapshotCapturePayload): Promise<SnapshotState> => ipcRenderer.invoke("snapshot:capture", payload),
+  recallSnapshot: (payload: SnapshotRecallPayload): Promise<boolean> => ipcRenderer.invoke("snapshot:recall", payload),
   onEvent: (listener: (evt: MidiEvent) => void) => {
     const handler = (_: Electron.IpcRendererEvent, data: MidiEvent) => listener(data);
     ipcRenderer.on("midi:event", handler);

--- a/apps/desktop/electron/projectStore.ts
+++ b/apps/desktop/electron/projectStore.ts
@@ -1,4 +1,4 @@
-import type { ProjectDocV1, ProjectStateV1 } from "../shared/projectTypes";
+import type { ProjectDoc, ProjectState } from "../shared/projectTypes";
 import { coerceProjectDoc, defaultProjectDoc } from "../shared/projectTypes";
 import { ProjectStorage } from "./projectStorage";
 
@@ -8,7 +8,7 @@ export type ProjectStoreOptions = {
 
 export class ProjectStore {
   private storage: ProjectStorage;
-  private current: ProjectDocV1 | null = null;
+  private current: ProjectDoc | null = null;
   private saveTimer: NodeJS.Timeout | null = null;
   private pendingSave: Promise<void> | null = null;
 
@@ -16,20 +16,20 @@ export class ProjectStore {
     this.storage = new ProjectStorage({ dir: opts.dir, filename: "project.json" });
   }
 
-  async load(): Promise<ProjectDocV1> {
+  async load(): Promise<ProjectDoc> {
     const raw = await this.storage.load(() => defaultProjectDoc());
     const doc = coerceProjectDoc(raw);
     this.current = doc;
     return doc;
   }
 
-  get(): ProjectDocV1 {
+  get(): ProjectDoc {
     return this.current ?? defaultProjectDoc();
   }
 
-  setState(state: ProjectStateV1): void {
-    const doc: ProjectDocV1 = {
-      schemaVersion: 1,
+  setState(state: ProjectState): void {
+    const doc: ProjectDoc = {
+      schemaVersion: 2,
       updatedAt: Date.now(),
       state
     };
@@ -56,4 +56,3 @@ export class ProjectStore {
     return this.pendingSave;
   }
 }
-

--- a/apps/desktop/electron/snapshotService.ts
+++ b/apps/desktop/electron/snapshotService.ts
@@ -1,0 +1,62 @@
+import type { MidiEvent, SnapshotRecallOptions, SnapshotState, TimedMidiSend } from "@midi-playground/core";
+import { SnapshotTracker, planSnapshotRecall } from "@midi-playground/core";
+import type { SnapshotCapturePayload, SnapshotRecallPayload } from "../shared/ipcTypes";
+import type { DeviceConfig } from "../shared/projectTypes";
+import type { MidiBridge } from "./midiBridge";
+
+export class SnapshotService {
+  private tracker = new SnapshotTracker();
+  private lastSnapshot: SnapshotState | null = null;
+
+  constructor(private midi: MidiBridge) {}
+
+  updateDevices(devices: DeviceConfig[]) {
+    this.tracker.updateBindings(
+      devices.map((d) => ({
+        deviceId: d.id,
+        outputId: d.outputId,
+        inputId: d.inputId ?? undefined,
+        channel: d.channel,
+        name: d.name
+      }))
+    );
+  }
+
+  ingest(evt: MidiEvent) {
+    this.tracker.ingest(evt);
+  }
+
+  capture(req?: SnapshotCapturePayload): SnapshotState {
+    if (req?.notes) {
+      this.tracker.setNotesMeta(req.notes);
+    }
+    const snapshot = this.tracker.capture({ notes: req?.notes, bpm: req?.bpm ?? undefined });
+    this.lastSnapshot = snapshot;
+    return snapshot;
+  }
+
+  recall(payload: SnapshotRecallPayload): boolean {
+    if (!payload?.snapshot) return false;
+    const options: SnapshotRecallOptions = {
+      from: this.lastSnapshot ?? this.tracker.getCurrentState(),
+      strategy: payload.strategy,
+      fadeMs: payload.fadeMs,
+      commitDelayMs: payload.commitDelayMs,
+      burst: payload.burst
+    };
+    const plan = planSnapshotRecall(payload.snapshot, options);
+    this.lastSnapshot = payload.snapshot;
+    this.execute(plan);
+    return true;
+  }
+
+  private execute(plan: TimedMidiSend[]) {
+    if (!plan.length) return;
+    for (const send of plan) {
+      setTimeout(() => {
+        this.midi.openOut(send.portId);
+        this.midi.send({ portId: send.portId, msg: send.msg });
+      }, send.delayMs);
+    }
+  }
+}

--- a/apps/desktop/shared/ipcTypes.ts
+++ b/apps/desktop/shared/ipcTypes.ts
@@ -1,4 +1,10 @@
-import type { ControlElement, MidiMsg } from "@midi-playground/core";
+import type {
+  ControlElement,
+  MidiMsg,
+  SnapshotBurstLimit,
+  SnapshotRecallStrategy,
+  SnapshotState
+} from "@midi-playground/core";
 
 export type MidiPortInfo = {
   id: string;
@@ -47,4 +53,17 @@ export type RouteConfig = {
   channelMode?: "passthrough" | "force";
   forceChannel?: number;
   filter?: RouteFilter;
+};
+
+export type SnapshotRecallPayload = {
+  snapshot: SnapshotState;
+  strategy: SnapshotRecallStrategy;
+  fadeMs?: number;
+  commitDelayMs?: number;
+  burst?: SnapshotBurstLimit;
+};
+
+export type SnapshotCapturePayload = {
+  notes?: string | null;
+  bpm?: number | null;
 };

--- a/apps/desktop/shared/projectTypes.ts
+++ b/apps/desktop/shared/projectTypes.ts
@@ -1,4 +1,4 @@
-import type { ControlElement } from "@midi-playground/core";
+import type { ControlElement, SnapshotBurstLimit, SnapshotRecallStrategy, SnapshotState } from "@midi-playground/core";
 import type { RouteConfig } from "./ipcTypes";
 
 export type DeviceConfig = {
@@ -11,13 +11,37 @@ export type DeviceConfig = {
   clockEnabled: boolean;
 };
 
-export type AppView = "setup" | "routes" | "mapping" | "monitor" | "help";
+export type AppView = "setup" | "routes" | "mapping" | "monitor" | "help" | "snapshots";
+
+export type SnapshotSlotState = {
+  id: string;
+  name: string;
+  lastCapturedAt: number | null;
+  snapshot: SnapshotState | null;
+  notes: string;
+};
+
+export type SnapshotBankState = {
+  id: string;
+  name: string;
+  slots: SnapshotSlotState[];
+};
+
+export type SnapshotsState = {
+  activeBankId: string | null;
+  strategy: SnapshotRecallStrategy;
+  fadeMs: number;
+  commitDelayMs: number;
+  burst: SnapshotBurstLimit;
+  captureNotes: string;
+  banks: SnapshotBankState[];
+};
 
 export type ProjectStateV1 = {
   backendId: string | null;
   selectedIn: string | null;
   selectedOut: string | null;
-  activeView: AppView;
+  activeView: Exclude<AppView, "snapshots">;
   selectedDeviceId: string | null;
   devices: DeviceConfig[];
   routes: RouteConfig[];
@@ -47,7 +71,51 @@ export type ProjectDocV1 = {
   state: ProjectStateV1;
 };
 
-export function defaultProjectState(): ProjectStateV1 {
+export type ProjectStateV2 = Omit<ProjectStateV1, "activeView"> & {
+  activeView: AppView;
+  snapshots: SnapshotsState;
+};
+
+export type ProjectDocV2 = {
+  schemaVersion: 2;
+  updatedAt: number;
+  state: ProjectStateV2;
+};
+
+export type ProjectState = ProjectStateV2;
+export type ProjectDoc = ProjectDocV2;
+
+function defaultSnapshotSlots(): SnapshotSlotState[] {
+  return Array.from({ length: 8 }, (_v, idx) => ({
+    id: `slot-${idx + 1}`,
+    name: `Slot ${idx + 1}`,
+    lastCapturedAt: null,
+    snapshot: null,
+    notes: ""
+  }));
+}
+
+function defaultSnapshotBanks(): SnapshotBankState[] {
+  return [
+    { id: "bank-1", name: "Bank A", slots: defaultSnapshotSlots() },
+    { id: "bank-2", name: "Bank B", slots: defaultSnapshotSlots() }
+  ];
+}
+
+export function defaultSnapshotsState(): SnapshotsState {
+  const banks = defaultSnapshotBanks();
+  return {
+    activeBankId: banks[0]?.id ?? null,
+    strategy: "jump",
+    fadeMs: 220,
+    commitDelayMs: 500,
+    burst: { intervalMs: 25, maxPerInterval: 12 },
+    captureNotes: "",
+    banks
+  };
+}
+
+function defaultProjectStateV1(): ProjectStateV1 {
   return {
     backendId: null,
     selectedIn: null,
@@ -77,9 +145,17 @@ export function defaultProjectState(): ProjectStateV1 {
   };
 }
 
-export function defaultProjectDoc(): ProjectDocV1 {
+export function defaultProjectState(): ProjectStateV2 {
   return {
-    schemaVersion: 1,
+    ...defaultProjectStateV1(),
+    activeView: "setup",
+    snapshots: defaultSnapshotsState()
+  };
+}
+
+export function defaultProjectDoc(): ProjectDocV2 {
+  return {
+    schemaVersion: 2,
     updatedAt: Date.now(),
     state: defaultProjectState()
   };
@@ -101,26 +177,90 @@ function asArray<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
 }
 
-export function coerceProjectDoc(raw: unknown): ProjectDocV1 {
-  const fallback = defaultProjectDoc();
-  if (!raw || typeof raw !== "object") return fallback;
+function coerceSnapshotSlot(raw: unknown, idx: number, fallbackName: string): SnapshotSlotState {
+  const rec = (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}) as Record<string, unknown>;
+  const capturedAt =
+    typeof rec.lastCapturedAt === "number" && Number.isFinite(rec.lastCapturedAt) ? rec.lastCapturedAt : null;
+  const snapshot = rec.snapshot && typeof rec.snapshot === "object" ? (rec.snapshot as SnapshotState) : null;
+  const fallbackSlot: SnapshotSlotState = {
+    id: typeof rec.id === "string" ? rec.id : `slot-${idx + 1}`,
+    name: typeof rec.name === "string" ? rec.name : fallbackName,
+    lastCapturedAt: capturedAt,
+    snapshot,
+    notes: typeof rec.notes === "string" ? rec.notes : ""
+  };
+  return fallbackSlot;
+}
 
-  const rec = raw as Record<string, unknown>;
-  if (rec.schemaVersion !== 1) return fallback;
+function coerceSnapshotBank(raw: unknown, idx: number): SnapshotBankState {
+  const rec = (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}) as Record<string, unknown>;
+  const slots = asArray(rec.slots).map((slot, slotIdx) => coerceSnapshotSlot(slot, slotIdx, `Slot ${slotIdx + 1}`));
+  return {
+    id: typeof rec.id === "string" ? rec.id : `bank-${idx + 1}`,
+    name: typeof rec.name === "string" ? rec.name : `Bank ${idx + 1}`,
+    slots: slots.length > 0 ? slots : defaultSnapshotSlots()
+  };
+}
 
-  const rawState = (rec.state && typeof rec.state === "object" ? (rec.state as Record<string, unknown>) : {}) as Record<
+function coerceSnapshotsState(raw: unknown): SnapshotsState {
+  const defaults = defaultSnapshotsState();
+  const rec = (raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {}) as Record<string, unknown>;
+  const banks = asArray(rec.banks).map((b, idx) => coerceSnapshotBank(b, idx));
+
+  const activeBankId =
+    typeof rec.activeBankId === "string"
+      ? rec.activeBankId
+      : banks.find((b) => b.id === defaults.activeBankId)?.id ?? defaults.activeBankId;
+
+  const strategy: SnapshotRecallStrategy = rec.strategy === "commit" ? "commit" : "jump";
+  const fadeMs = Math.max(0, asNumberOr(rec.fadeMs, defaults.fadeMs));
+  const commitDelayMs = Math.max(0, asNumberOr(rec.commitDelayMs, defaults.commitDelayMs));
+
+  const burstDefaults = defaults.burst;
+  const burstRec = ((rec.burst && typeof rec.burst === "object") ? (rec.burst as Record<string, unknown>) : {}) as Record<
     string,
     unknown
   >;
-  const stateDefaults = defaultProjectState();
+  const burst: SnapshotBurstLimit = {
+    intervalMs: Math.max(1, asNumberOr(burstRec.intervalMs, burstDefaults.intervalMs)),
+    maxPerInterval: Math.max(1, asNumberOr(burstRec.maxPerInterval, burstDefaults.maxPerInterval))
+  };
 
-  const view = rawState.activeView;
+  return {
+    activeBankId,
+    strategy,
+    fadeMs,
+    commitDelayMs,
+    captureNotes: typeof rec.captureNotes === "string" ? rec.captureNotes : defaults.captureNotes,
+    burst,
+    banks: banks.length > 0 ? banks : defaults.banks
+  };
+}
+
+function sanitizeAppView(raw: unknown): AppView {
+  const view = raw as AppView;
+  return view === "setup" ||
+    view === "routes" ||
+    view === "mapping" ||
+    view === "monitor" ||
+    view === "help" ||
+    view === "snapshots"
+    ? view
+    : "setup";
+}
+
+function coerceProjectStateV1(rawState: unknown): ProjectStateV1 {
+  const stateDefaults = defaultProjectStateV1();
+  const raw = (rawState && typeof rawState === "object" ? (rawState as Record<string, unknown>) : {}) as Record<
+    string,
+    unknown
+  >;
+
+  const view = raw.activeView;
   const activeView: AppView =
-    view === "setup" || view === "routes" || view === "mapping" || view === "monitor" || view === "help"
-      ? view
-      : "setup";
+    view === "setup" || view === "routes" || view === "mapping" || view === "monitor" || view === "help" ? view : "setup";
 
-  const devices: DeviceConfig[] = asArray<Record<string, unknown>>(rawState.devices).map((d, idx) => ({
+  const devices: DeviceConfig[] = asArray<Record<string, unknown>>(raw.devices).map((d, idx) => ({
     id: typeof d.id === "string" ? d.id : `device-${idx + 1}`,
     name: typeof d.name === "string" ? d.name : `Device ${idx + 1}`,
     instrumentId: asStringOrNull(d.instrumentId),
@@ -131,49 +271,86 @@ export function coerceProjectDoc(raw: unknown): ProjectDocV1 {
   }));
 
   return {
-    schemaVersion: 1,
-    updatedAt: asNumberOr(rec.updatedAt, Date.now()),
-    state: {
-      backendId: asStringOrNull(rawState.backendId),
-      selectedIn: asStringOrNull(rawState.selectedIn),
-      selectedOut: asStringOrNull(rawState.selectedOut),
-      activeView,
-      selectedDeviceId: asStringOrNull(rawState.selectedDeviceId),
-      devices,
-      routes: asArray<RouteConfig>(rawState.routes),
-      controls: asArray<ControlElement>(rawState.controls),
-      selectedControlId: asStringOrNull(rawState.selectedControlId),
-      ui: {
-        routeBuilder: {
-          forceChannelEnabled: asBooleanOr((rawState.ui as any)?.routeBuilder?.forceChannelEnabled, stateDefaults.ui.routeBuilder.forceChannelEnabled),
-          routeChannel: Math.min(
-            Math.max(Math.round(asNumberOr((rawState.ui as any)?.routeBuilder?.routeChannel, stateDefaults.ui.routeBuilder.routeChannel)), 1),
-            16
-          ),
-          allowNotes: asBooleanOr((rawState.ui as any)?.routeBuilder?.allowNotes, stateDefaults.ui.routeBuilder.allowNotes),
-          allowCc: asBooleanOr((rawState.ui as any)?.routeBuilder?.allowCc, stateDefaults.ui.routeBuilder.allowCc),
-          allowExpression: asBooleanOr(
-            (rawState.ui as any)?.routeBuilder?.allowExpression,
-            stateDefaults.ui.routeBuilder.allowExpression
-          ),
-          allowTransport: asBooleanOr(
-            (rawState.ui as any)?.routeBuilder?.allowTransport,
-            stateDefaults.ui.routeBuilder.allowTransport
-          ),
-          allowClock: asBooleanOr((rawState.ui as any)?.routeBuilder?.allowClock, stateDefaults.ui.routeBuilder.allowClock),
-          clockDiv: Math.min(
-            Math.max(Math.round(asNumberOr((rawState.ui as any)?.routeBuilder?.clockDiv, stateDefaults.ui.routeBuilder.clockDiv)), 1),
-            96
-          )
-        },
-        diagnostics: {
-          note: Math.min(Math.max(Math.round(asNumberOr((rawState.ui as any)?.diagnostics?.note, stateDefaults.ui.diagnostics.note)), 0), 127),
-          ccValue: Math.min(
-            Math.max(Math.round(asNumberOr((rawState.ui as any)?.diagnostics?.ccValue, stateDefaults.ui.diagnostics.ccValue)), 0),
-            127
-          )
-        }
+    backendId: asStringOrNull(raw.backendId),
+    selectedIn: asStringOrNull(raw.selectedIn),
+    selectedOut: asStringOrNull(raw.selectedOut),
+    activeView,
+    selectedDeviceId: asStringOrNull(raw.selectedDeviceId),
+    devices,
+    routes: asArray<RouteConfig>(raw.routes),
+    controls: asArray<ControlElement>(raw.controls),
+    selectedControlId: asStringOrNull(raw.selectedControlId),
+    ui: {
+      routeBuilder: {
+        forceChannelEnabled: asBooleanOr((raw.ui as any)?.routeBuilder?.forceChannelEnabled, stateDefaults.ui.routeBuilder.forceChannelEnabled),
+        routeChannel: Math.min(
+          Math.max(Math.round(asNumberOr((raw.ui as any)?.routeBuilder?.routeChannel, stateDefaults.ui.routeBuilder.routeChannel)), 1),
+          16
+        ),
+        allowNotes: asBooleanOr((raw.ui as any)?.routeBuilder?.allowNotes, stateDefaults.ui.routeBuilder.allowNotes),
+        allowCc: asBooleanOr((raw.ui as any)?.routeBuilder?.allowCc, stateDefaults.ui.routeBuilder.allowCc),
+        allowExpression: asBooleanOr((raw.ui as any)?.routeBuilder?.allowExpression, stateDefaults.ui.routeBuilder.allowExpression),
+        allowTransport: asBooleanOr((raw.ui as any)?.routeBuilder?.allowTransport, stateDefaults.ui.routeBuilder.allowTransport),
+        allowClock: asBooleanOr((raw.ui as any)?.routeBuilder?.allowClock, stateDefaults.ui.routeBuilder.allowClock),
+        clockDiv: Math.min(
+          Math.max(Math.round(asNumberOr((raw.ui as any)?.routeBuilder?.clockDiv, stateDefaults.ui.routeBuilder.clockDiv)), 1),
+          96
+        )
+      },
+      diagnostics: {
+        note: Math.min(Math.max(Math.round(asNumberOr((raw.ui as any)?.diagnostics?.note, stateDefaults.ui.diagnostics.note)), 0), 127),
+        ccValue: Math.min(
+          Math.max(Math.round(asNumberOr((raw.ui as any)?.diagnostics?.ccValue, stateDefaults.ui.diagnostics.ccValue)), 0),
+          127
+        )
       }
     }
+  };
+}
+
+function upgradeToV2(state: ProjectStateV1): ProjectStateV2 {
+  return {
+    ...state,
+    activeView: sanitizeAppView(state.activeView),
+    snapshots: defaultSnapshotsState()
+  };
+}
+
+function coerceProjectStateV2(rawState: unknown): ProjectStateV2 {
+  const base = coerceProjectStateV1(rawState);
+  const raw = (rawState && typeof rawState === "object" ? (rawState as Record<string, unknown>) : {}) as Record<
+    string,
+    unknown
+  >;
+  const snapshots = coerceSnapshotsState((raw as any)?.snapshots);
+  return {
+    ...base,
+    activeView: sanitizeAppView((raw as any)?.activeView),
+    snapshots
+  };
+}
+
+export function coerceProjectDoc(raw: unknown): ProjectDocV2 {
+  const fallback = defaultProjectDoc();
+  if (!raw || typeof raw !== "object") return fallback;
+
+  const rec = raw as Record<string, unknown>;
+  const updatedAt = asNumberOr(rec.updatedAt, Date.now());
+
+  if (rec.schemaVersion === 1) {
+    const v1State = coerceProjectStateV1((rec as any).state);
+    return {
+      schemaVersion: 2,
+      updatedAt,
+      state: upgradeToV2(v1State)
+    };
+  }
+
+  if (rec.schemaVersion !== 2) return fallback;
+
+  return {
+    schemaVersion: 2,
+    updatedAt,
+    state: coerceProjectStateV2((rec as any).state)
   };
 }

--- a/apps/desktop/src/types/preload.d.ts
+++ b/apps/desktop/src/types/preload.d.ts
@@ -1,6 +1,14 @@
-import type { MidiEvent } from "@midi-playground/core";
-import type { MappingEmitPayload, MidiBackendInfo, MidiPorts, MidiSendPayload, RouteConfig } from "../../shared/ipcTypes";
-import type { ProjectDocV1, ProjectStateV1 } from "../../shared/projectTypes";
+import type { MidiEvent, SnapshotState } from "@midi-playground/core";
+import type {
+  MappingEmitPayload,
+  MidiBackendInfo,
+  MidiPorts,
+  MidiSendPayload,
+  RouteConfig,
+  SnapshotCapturePayload,
+  SnapshotRecallPayload
+} from "../../shared/ipcTypes";
+import type { ProjectDoc, ProjectState } from "../../shared/projectTypes";
 
 export type MidiApi = {
   listPorts: () => Promise<MidiPorts>;
@@ -11,9 +19,11 @@ export type MidiApi = {
   send: (payload: MidiSendPayload) => Promise<boolean>;
   emitMapping: (payload: MappingEmitPayload) => Promise<boolean>;
   setRoutes: (routes: RouteConfig[]) => Promise<boolean>;
-  loadProject: () => Promise<ProjectDocV1 | null>;
-  setProjectState: (state: ProjectStateV1) => Promise<boolean>;
+  loadProject: () => Promise<ProjectDoc | null>;
+  setProjectState: (state: ProjectState) => Promise<boolean>;
   flushProject: () => Promise<boolean>;
+  captureSnapshot: (payload?: SnapshotCapturePayload) => Promise<SnapshotState>;
+  recallSnapshot: (payload: SnapshotRecallPayload) => Promise<boolean>;
   onEvent: (listener: (evt: MidiEvent) => void) => () => void;
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,6 @@ export * from "./mapping/curves";
 export * from "./mapping/engine";
 export * from "./routing/graph";
 export * from "./sequencers/types";
+export * from "./snapshots/types";
+export * from "./snapshots/tracker";
+export * from "./snapshots/recall";

--- a/packages/core/src/snapshots/recall.ts
+++ b/packages/core/src/snapshots/recall.ts
@@ -1,0 +1,116 @@
+import type { MidiMsg } from "../midi/types";
+import type {
+  SnapshotBurstLimit,
+  SnapshotDeviceState,
+  SnapshotRecallOptions,
+  SnapshotRecallStrategy,
+  SnapshotState,
+  TimedMidiSend
+} from "./types";
+
+type DeviceMap = Map<string, SnapshotDeviceState>;
+
+const DEFAULT_COMMIT_MS = 500;
+
+export function planSnapshotRecall(target: SnapshotState, options: SnapshotRecallOptions): TimedMidiSend[] {
+  const from = options.from ?? null;
+  const fromDevices = mapDevices(from);
+  const targetDevices = mapDevices(target);
+  const baseDelay = options.strategy === "commit" ? chooseCommitDelay(target, options.strategy, options.commitDelayMs) : 0;
+
+  const sends: TimedMidiSend[] = [];
+
+  for (const device of targetDevices.values()) {
+    if (!device.outputId) continue;
+    const previous = fromDevices.get(device.deviceId);
+
+    if (device.program !== undefined && device.program !== previous?.program) {
+      sends.push(makeTimedSend(device.outputId, { t: "programChange", ch: device.channel, program: device.program }, baseDelay));
+    }
+
+    const fadeMs = options.fadeMs && options.fadeMs > 0 ? options.fadeMs : 0;
+    const ccEntries = Object.entries(device.cc ?? {});
+    for (const [ccKey, targetValRaw] of ccEntries) {
+      const cc = Number(ccKey);
+      if (!Number.isFinite(cc)) continue;
+      const targetVal = clampMidi(targetValRaw);
+      const fromVal = previous?.cc?.[cc];
+      if (fadeMs > 0 && typeof fromVal === "number" && fromVal !== targetVal) {
+        const steps = Math.max(1, Math.round(fadeMs / 40));
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps;
+          const value = clampMidi(Math.round(fromVal + (targetVal - fromVal) * t));
+          sends.push(makeTimedSend(device.outputId, { t: "cc", ch: device.channel, cc, val: value }, baseDelay + Math.round(fadeMs * t)));
+        }
+      } else {
+        sends.push(makeTimedSend(device.outputId, { t: "cc", ch: device.channel, cc, val: targetVal }, baseDelay));
+      }
+    }
+
+    const previousNotes = new Map<number, number>();
+    previous?.notes?.forEach((n) => previousNotes.set(n.note, n.vel));
+
+    for (const [note, _vel] of previousNotes.entries()) {
+      if (!device.notes.some((n) => n.note === note)) {
+        sends.push(makeTimedSend(device.outputId, { t: "noteOff", ch: device.channel, note, vel: 0 }, baseDelay));
+      }
+    }
+
+    for (const noteState of device.notes) {
+      sends.push(makeTimedSend(device.outputId, { t: "noteOn", ch: device.channel, note: noteState.note, vel: noteState.vel }, baseDelay + 20));
+    }
+  }
+
+  const limiter = options.burst;
+  const limited = limiter ? applyBurstLimit(sends, limiter) : sends;
+  return limited.sort((a, b) => a.delayMs - b.delayMs);
+}
+
+function mapDevices(state: SnapshotState | null): DeviceMap {
+  const map: DeviceMap = new Map();
+  if (!state) return map;
+  for (const dev of state.devices ?? []) {
+    map.set(dev.deviceId, dev);
+  }
+  return map;
+}
+
+function chooseCommitDelay(target: SnapshotState, _strategy: SnapshotRecallStrategy, override?: number): number {
+  if (typeof override === "number" && override >= 0) return override;
+  if (target.bpm && target.bpm > 0) {
+    return Math.round((60000 / target.bpm) * 4);
+  }
+  return DEFAULT_COMMIT_MS;
+}
+
+function applyBurstLimit(sends: TimedMidiSend[], limit: SnapshotBurstLimit): TimedMidiSend[] {
+  const maxPer = Math.max(1, limit.maxPerInterval);
+  const interval = Math.max(1, limit.intervalMs);
+  const ordered = [...sends].sort((a, b) => a.delayMs - b.delayMs);
+  let windowStart = 0;
+  let count = 0;
+
+  return ordered.map((send) => {
+    let delay = send.delayMs;
+    if (delay >= windowStart + interval) {
+      windowStart = delay;
+      count = 0;
+    }
+    if (count >= maxPer) {
+      windowStart += interval;
+      count = 0;
+      delay = Math.max(delay, windowStart);
+    }
+    count += 1;
+    return { ...send, delayMs: delay };
+  });
+}
+
+function makeTimedSend(portId: string, msg: MidiMsg, delayMs: number): TimedMidiSend {
+  return { portId, msg, delayMs: Math.max(0, Math.round(delayMs)) };
+}
+
+function clampMidi(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 127);
+}

--- a/packages/core/src/snapshots/tracker.ts
+++ b/packages/core/src/snapshots/tracker.ts
@@ -1,0 +1,179 @@
+import type { MidiEvent } from "../midi/types";
+import type { SnapshotDeviceBinding, SnapshotDeviceState, SnapshotNoteState, SnapshotState } from "./types";
+
+type DeviceRuntimeState = {
+  binding: SnapshotDeviceBinding;
+  cc: Map<number, number>;
+  notes: Map<number, number>;
+  program?: number;
+};
+
+function clampChannel(ch: number | undefined) {
+  if (!Number.isFinite(ch)) return 1;
+  return Math.min(Math.max(Math.round(ch as number), 1), 16);
+}
+
+function clampMidi(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.round(value), 0), 127);
+}
+
+const CLOCKS_PER_QUARTER = 24;
+
+export class SnapshotTracker {
+  private bindings = new Map<string, SnapshotDeviceBinding>();
+  private devices = new Map<string, DeviceRuntimeState>();
+  private lastClockTs: number | null = null;
+  private clockIntervals: number[] = [];
+  private notesMeta: string | null = null;
+  private bpm: number | null = null;
+
+  constructor(bindings: SnapshotDeviceBinding[] = []) {
+    this.updateBindings(bindings);
+  }
+
+  updateBindings(bindings: SnapshotDeviceBinding[]) {
+    this.bindings.clear();
+    const nextBindings = bindings.filter((b) => !!b.deviceId);
+    for (const binding of nextBindings) {
+      const existing = this.devices.get(binding.deviceId);
+      const state: DeviceRuntimeState = existing ?? {
+        binding,
+        cc: new Map(),
+        notes: new Map()
+      };
+      state.binding = binding;
+      this.devices.set(binding.deviceId, state);
+
+      if (binding.outputId) {
+        this.bindings.set(binding.outputId, binding);
+        this.bindings.set(`out:${binding.outputId}`, binding);
+      }
+      if (binding.inputId) {
+        this.bindings.set(binding.inputId, binding);
+      }
+    }
+  }
+
+  setNotesMeta(notes: string | null) {
+    this.notesMeta = notes ?? null;
+  }
+
+  ingest(evt: MidiEvent) {
+    if (evt.msg.t === "clock") {
+      this.handleClock();
+      return;
+    }
+    if (evt.msg.t === "start" || evt.msg.t === "stop") {
+      this.resetClock();
+      return;
+    }
+
+    const binding = this.bindingForPort(evt.src.id);
+    if (!binding) return;
+
+    const device = this.ensureDevice(binding.deviceId, binding);
+
+    switch (evt.msg.t) {
+      case "cc":
+        device.cc.set(clampMidi(evt.msg.cc), clampMidi(evt.msg.val));
+        break;
+      case "programChange":
+        device.program = clampMidi(evt.msg.program);
+        break;
+      case "noteOn": {
+        const vel = clampMidi(evt.msg.vel);
+        if (vel <= 0) {
+          device.notes.delete(clampMidi(evt.msg.note));
+        } else {
+          device.notes.set(clampMidi(evt.msg.note), vel);
+        }
+        break;
+      }
+      case "noteOff":
+        device.notes.delete(clampMidi(evt.msg.note));
+        break;
+      default:
+        break;
+    }
+  }
+
+  capture(meta?: { notes?: string | null; bpm?: number | null }): SnapshotState {
+    const devices: SnapshotDeviceState[] = [];
+    const snapshotNotes = typeof meta?.notes === "string" ? meta?.notes : this.notesMeta;
+
+    for (const state of this.devices.values()) {
+      const cc: Record<number, number> = {};
+      state.cc.forEach((value, ccNum) => {
+        cc[clampMidi(ccNum)] = clampMidi(value);
+      });
+      const notes: SnapshotNoteState[] = [];
+      state.notes.forEach((vel, note) => {
+        notes.push({ note: clampMidi(note), vel: clampMidi(vel) });
+      });
+      devices.push({
+        deviceId: state.binding.deviceId,
+        outputId: state.binding.outputId ?? null,
+        channel: clampChannel(state.binding.channel),
+        cc,
+        program: state.program,
+        notes,
+        name: state.binding.name ?? undefined
+      });
+    }
+
+    return {
+      capturedAt: Date.now(),
+      bpm: typeof meta?.bpm === "number" ? meta?.bpm : this.bpm,
+      notes: snapshotNotes ?? null,
+      devices
+    };
+  }
+
+  getCurrentState(): SnapshotState {
+    return this.capture();
+  }
+
+  private ensureDevice(id: string, binding: SnapshotDeviceBinding): DeviceRuntimeState {
+    let device = this.devices.get(id);
+    if (!device) {
+      device = { binding, cc: new Map(), notes: new Map() };
+      this.devices.set(id, device);
+    } else {
+      device.binding = binding;
+    }
+    return device;
+  }
+
+  private bindingForPort(portId: string): SnapshotDeviceBinding | null {
+    const found = this.bindings.get(portId);
+    if (found) return found;
+    if (portId.startsWith("out:") || portId.startsWith("in:")) {
+      const normalized = portId.slice(portId.indexOf(":") + 1);
+      return this.bindings.get(normalized) ?? null;
+    }
+    return null;
+  }
+
+  private handleClock() {
+    const now = Date.now();
+    if (this.lastClockTs != null) {
+      const delta = now - this.lastClockTs;
+      if (delta > 0) {
+        this.clockIntervals.push(delta);
+        if (this.clockIntervals.length > 12) {
+          this.clockIntervals.shift();
+        }
+        const avg = this.clockIntervals.reduce((acc, n) => acc + n, 0) / this.clockIntervals.length;
+        const bpm = 60000 / (avg * CLOCKS_PER_QUARTER);
+        this.bpm = Math.round(bpm);
+      }
+    }
+    this.lastClockTs = now;
+  }
+
+  private resetClock() {
+    this.clockIntervals = [];
+    this.lastClockTs = null;
+  }
+}

--- a/packages/core/src/snapshots/types.ts
+++ b/packages/core/src/snapshots/types.ts
@@ -1,0 +1,49 @@
+import type { MidiMsg } from "../midi/types";
+
+export type SnapshotNoteState = { note: number; vel: number };
+
+export type SnapshotDeviceBinding = {
+  deviceId: string;
+  outputId: string | null;
+  inputId?: string | null;
+  channel: number;
+  name?: string | null;
+};
+
+export type SnapshotDeviceState = {
+  deviceId: string;
+  outputId: string | null;
+  channel: number;
+  cc: Record<number, number>;
+  program?: number;
+  notes: SnapshotNoteState[];
+  name?: string | null;
+};
+
+export type SnapshotState = {
+  capturedAt: number;
+  bpm: number | null;
+  notes: string | null;
+  devices: SnapshotDeviceState[];
+};
+
+export type SnapshotRecallStrategy = "jump" | "commit";
+
+export type SnapshotBurstLimit = {
+  maxPerInterval: number;
+  intervalMs: number;
+};
+
+export type TimedMidiSend = {
+  portId: string;
+  msg: MidiMsg;
+  delayMs: number;
+};
+
+export type SnapshotRecallOptions = {
+  from?: SnapshotState | null;
+  strategy: SnapshotRecallStrategy;
+  fadeMs?: number;
+  commitDelayMs?: number;
+  burst?: SnapshotBurstLimit;
+};


### PR DESCRIPTION
## Summary
- add core snapshot tracker and recall planner with jump/commit strategies and burst limiting
- migrate project schema to v2 with persisted snapshot banks/slots and desktop snapshot service wiring
- extend renderer UI to manage snapshot banks, capture state, and trigger recalls via midi bridge

## Testing
- pnpm -C apps/desktop build:main
- pnpm -C apps/desktop build:renderer

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69439cd073ec83319064c6b762a2e072)