### PR TITLE
Add shared sequencer state defaults

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3,14 +3,16 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { computeMappingSends } from "@midi-playground/core";
 import type { MidiEvent } from "@midi-playground/core";
 import type { MappingEmitPayload, MidiSendPayload, RouteConfig } from "../shared/ipcTypes";
-import type { ProjectStateV1 } from "../shared/projectTypes";
+import type { ProjectState, SequencerApplyPayload } from "../shared/projectTypes";
 import type { BackendId } from "./backends/types";
 import { MidiBridge } from "./midiBridge";
 import { ProjectStore } from "./projectStore";
 import { SnapshotService } from "./snapshotService";
+import { SequencerHost } from "./sequencerHost";
 
 const midiBridge = new MidiBridge();
 const snapshotService = new SnapshotService(midiBridge);
+const sequencerHost = new SequencerHost(midiBridge);
 let projectStore: ProjectStore | null = null;
 const isDev = !app.isPackaged;
 const appDir = __dirname;

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -9,7 +9,7 @@ import type {
   SnapshotCapturePayload,
   SnapshotRecallPayload
 } from "../shared/ipcTypes";
-import type { ProjectDoc, ProjectState } from "../shared/projectTypes";
+import type { ProjectDoc, ProjectState, SequencerApplyPayload } from "../shared/projectTypes";
 
 const midiApi = {
   listPorts: (): Promise<MidiPorts> => ipcRenderer.invoke("midi:listPorts"),
@@ -25,6 +25,7 @@ const midiApi = {
   flushProject: (): Promise<boolean> => ipcRenderer.invoke("project:flush"),
   captureSnapshot: (payload?: SnapshotCapturePayload): Promise<SnapshotState> => ipcRenderer.invoke("snapshot:capture", payload),
   recallSnapshot: (payload: SnapshotRecallPayload): Promise<boolean> => ipcRenderer.invoke("snapshot:recall", payload),
+  applySequencer: (payload: SequencerApplyPayload): Promise<boolean> => ipcRenderer.invoke("sequencer:apply", payload),
   onEvent: (listener: (evt: MidiEvent) => void) => {
     const handler = (_: Electron.IpcRendererEvent, data: MidiEvent) => listener(data);
     ipcRenderer.on("midi:event", handler);

--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -17,11 +17,21 @@ import type {
   SnapshotCapturePayload,
   SnapshotRecallPayload
 } from "../../shared/ipcTypes";
-import { defaultProjectState } from "../../shared/projectTypes";
+import {
+  MAX_SEQUENCER_CHAINS,
+  MAX_SEQUENCER_STEPS,
+  defaultProjectState,
+  defaultSequencerState,
+  defaultSequencerStep
+} from "../../shared/projectTypes";
 import type {
   AppView,
   DeviceConfig,
   ProjectState,
+  SequencerApplyPayload,
+  SequencerChainConfig,
+  SequencerProjectState,
+  SequencerStepConfig,
   SnapshotBankState,
   SnapshotSlotState,
   SnapshotsState

--- a/apps/desktop/src/types/preload.d.ts
+++ b/apps/desktop/src/types/preload.d.ts
@@ -8,7 +8,7 @@ import type {
   SnapshotCapturePayload,
   SnapshotRecallPayload
 } from "../../shared/ipcTypes";
-import type { ProjectDoc, ProjectState } from "../../shared/projectTypes";
+import type { ProjectDoc, ProjectState, SequencerApplyPayload } from "../../shared/projectTypes";
 
 export type MidiApi = {
   listPorts: () => Promise<MidiPorts>;
@@ -24,6 +24,7 @@ export type MidiApi = {
   flushProject: () => Promise<boolean>;
   captureSnapshot: (payload?: SnapshotCapturePayload) => Promise<SnapshotState>;
   recallSnapshot: (payload: SnapshotRecallPayload) => Promise<boolean>;
+  applySequencer: (payload: SequencerApplyPayload) => Promise<boolean>;
   onEvent: (listener: (evt: MidiEvent) => void) => () => void;
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./mapping/types";
 export * from "./mapping/curves";
 export * from "./mapping/engine";
 export * from "./routing/graph";
+export * from "./sequencers/runner";
 export * from "./sequencers/types";
 export * from "./snapshots/types";
 export * from "./snapshots/tracker";


### PR DESCRIPTION
## Summary
- add shared sequencer types, defaults, and coercion helpers for project state
- wire renderer, preload, and main IPC to use the shared sequencer helpers instead of implicit globals
- export the sequencer runner surface from the core package for desktop usage

## Testing
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446110966c83318a5c9c255943aba8)