### PR TITLE
Update roadmap with stage view progress

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,9 @@
 
 Goal: Build a snapshot-driven performance controller in software, using the OXI One as the hardware router (app + OXI over USB MIDI, OXI routes DIN/TRS downstream). Platform: Windows with Electron/React front-end and dual MIDI backends (WinMM fallback, Windows MIDI Services when available).
 
-Current status (Dec 2025): Surfaces board and control primitives are live and emit mapped MIDI; mapping page has per-slot editing and a stub assignment wizard; snapshot pads/morph UI refreshed; macro multi-bind demo with rate limiting exists in the lab.
+Current status (Dec 2025): Surfaces board and control primitives are live and emit mapped MIDI; mapping page has per-slot editing and a stub assignment wizard; snapshot pads/morph UI refreshed; macro multi-bind demo with rate limiting exists in the lab. A new Stage/Performance layout (Neuzeit Drop + Condukt-inspired) is being prototyped to unify scene launch, transition “Drop” fader, and rig-aware instrument strips for the OXI-driven setup (Monologue, MicroFreak, Pro VS Mini, Digitakt).
+
+Status vs goals: Phase 0–2 shipped; Phase 3 snapshot features are in-progress (pads/morph UI ready, transition scheduling and burst limiting next); Phase 4 performance surfaces are moving with the Stage view prototype; Phase 7 OXI transport consumption is queued to align drops to clock/transport.
 
 ## Phases
 
@@ -32,6 +34,7 @@ Current status (Dec 2025): Surfaces board and control primitives are live and em
 
 - **Phase 4 - Performance surfaces (Condukt-inspired)**
   - Board/page system: Sound Design Lab (dense editing), Performance surface (macro faders/XY), Mix desk (levels/pan/mutes); one-tap page switching.
+  - Stage view (Neuzeit Drop + Condukt mashup): scene launcher with quantized “Drop” transitions, transition progress fader, and rig-aware instrument strips for OXI lanes 1–4 (Monologue, MicroFreak, Pro VS Mini, Digitakt).
   - Resizable controls (fader/knob/crossfader/button/step grid) with orientation presets (1x2, 1x3, 2x1, 3x1) and multi-touch; includes value taper and coarse/fine drag.
   - Macro faders driving multiple targets with per-target min/max, curve type (linear/inverse/exponential/log), and optional channel overrides; bi-directional feedback rendering.
   - Instrument-aware picker: browse/search CC/NRPN by name/category; quick-add sets for envelopes, filters, LFOs, sequencer params; assignment wizard for rapid multi-bind and bulk color tagging.
@@ -87,5 +90,6 @@ Current status (Dec 2025): Surfaces board and control primitives are live and em
 - UI primitives (P0): fader/knob/crossfader/button/step grid with resize/orientation presets, coarse/fine drag, and bi-directional value feedback. DoD: reusable components, unit snapshot of value rendering, event plumbing to mapping engine stub.
 - Assignment wizard (P0): instrument-aware picker (search/browse CC/NRPN), bulk bind to macros/pads with per-target curves and color tags. DoD: can multi-bind 3+ targets in one flow, writes bindings to mapping engine, preserves tags.
 - Snapshot morphing (P0): pads grid + crossfader with staged per-parameter curves; per-parameter slew config; rate-limit burst sends. DoD: morph between two saved states with per-parameter curves; sends rate-limited; visual feedback of current morph position.
+- Stage mode (P0): Stage page with scene launcher, Drop/transition fader, rig-aware instrument strips for OXI lanes 1–4, and global macros that fan out CCs across multiple synths. DoD: one-to-many macro routing works end-to-end, scene launches can quantize to clock/transport, UI reflects rig device health.
 - Software modulation (P0): LFO engine (shapes/divisions/depth/phase) and parameter sequencer lanes (probability/density/curves/lock to snapshots) with throughput guardrails. DoD: run 3 LFOs + 2 sequencer lanes concurrently without buffer overrun; per-lane on/off and depth.
 - Mixer template (P1): 8-16 channel layout with mute/solo, level/pan, and global send macros; theming hooks for stage/studio skins. DoD: template instantiates from device list; mutes/solos round-trip to mapping; global send macro drives multiple channels.


### PR DESCRIPTION
## Summary
- note Stage/Performance UI prototype inspired by Neuzeit Drop and Condukt
- capture status against roadmap phases, highlighting ongoing Stage and OXI transport alignment
- add Stage mode to immediate tickets for P0 delivery criteria

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ea0352c483318a41440e96c17000)