### PR TITLE
Add stage slice persistence and preset import/export

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3,7 +3,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { computeMappingSends } from "@midi-playground/core";
 import type { MidiEvent } from "@midi-playground/core";
 import type { MappingEmitPayload, MidiSendPayload, RouteConfig } from "../shared/ipcTypes";
-import type { ProjectStateV1 } from "../shared/projectTypes";
+import type { ProjectState } from "../shared/projectTypes";
 import type { BackendId } from "./backends/types";
 import { MidiBridge } from "./midiBridge";
 import { ProjectStore } from "./projectStore";

--- a/apps/desktop/shared/projectTypes.ts
+++ b/apps/desktop/shared/projectTypes.ts
@@ -1,4 +1,5 @@
 import type { ControlElement } from "@midi-playground/core";
+import { coerceStageState, defaultStageState, type StageState } from "./stageTypes";
 import type { RouteConfig } from "./ipcTypes";
 
 export type SnapshotQuantize = "immediate" | "bar1" | "bar4";
@@ -21,6 +22,7 @@ export type AppView =
   | "mapping"
   | "monitor"
   | "help"
+  | "stage"
   | "snapshots"
   | "chains"
   | "settings"
@@ -43,6 +45,7 @@ export type ProjectStateV1 = {
   routes: RouteConfig[];
   controls: ControlElement[];
   selectedControlId: string | null;
+  stage: StageState;
   ui: {
     routeBuilder: {
       forceChannelEnabled: boolean;
@@ -90,6 +93,7 @@ export function defaultProjectState(): ProjectStateV1 {
     routes: [],
     controls: [],
     selectedControlId: null,
+    stage: defaultStageState(),
     ui: {
       routeBuilder: {
         forceChannelEnabled: true,
@@ -174,6 +178,7 @@ export function coerceProjectDoc(raw: unknown): ProjectDocV1 {
     view === "mapping" ||
     view === "monitor" ||
     view === "help" ||
+    view === "stage" ||
     view === "snapshots" ||
     view === "chains" ||
     view === "settings" ||
@@ -215,6 +220,7 @@ export function coerceProjectDoc(raw: unknown): ProjectDocV1 {
       routes: asArray<RouteConfig>(rawState.routes),
       controls: asArray<ControlElement>(rawState.controls),
       selectedControlId: asStringOrNull(rawState.selectedControlId),
+      stage: coerceStageState(rawState.stage, stateDefaults.stage),
       ui: {
         routeBuilder: {
           forceChannelEnabled: asBooleanOr((rawState.ui as any)?.routeBuilder?.forceChannelEnabled, stateDefaults.ui.routeBuilder.forceChannelEnabled),
@@ -256,3 +262,6 @@ export function coerceProjectDoc(raw: unknown): ProjectDocV1 {
     }
   };
 }
+
+export type ProjectState = ProjectStateV1;
+export type ProjectDoc = ProjectDocV1;

--- a/apps/desktop/shared/stageTypes.ts
+++ b/apps/desktop/shared/stageTypes.ts
@@ -1,0 +1,150 @@
+export type StageScene = {
+  id: string;
+  name: string;
+  notes?: string;
+};
+
+export type StageMacroValues = Record<string, number>;
+
+export type StageInstrumentPreset = {
+  instrumentId: string;
+  name: string;
+  values: Record<string, number>;
+};
+
+export type StageRigState = {
+  scenes: StageScene[];
+  macros: StageMacroValues;
+  instrumentPresets: Record<string, StageInstrumentPreset>;
+};
+
+export type StageState = {
+  activeRigId: string;
+  rigs: Record<string, StageRigState>;
+};
+
+function clampMidi(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(127, Math.max(0, Math.round(value)));
+}
+
+function coerceScene(raw: unknown, idx: number): StageScene {
+  if (!raw || typeof raw !== "object") {
+    return { id: `scene-${idx + 1}`, name: `Scene ${idx + 1}` };
+  }
+  const rec = raw as Record<string, unknown>;
+  const id = typeof rec.id === "string" && rec.id.trim() ? rec.id : `scene-${idx + 1}`;
+  const name = typeof rec.name === "string" && rec.name.trim() ? rec.name : `Scene ${idx + 1}`;
+  const notes = typeof rec.notes === "string" ? rec.notes : undefined;
+  return { id, name, ...(notes ? { notes } : {}) };
+}
+
+function coercePreset(raw: unknown): StageInstrumentPreset | null {
+  if (!raw || typeof raw !== "object") return null;
+  const rec = raw as Record<string, unknown>;
+  const instrumentId = typeof rec.instrumentId === "string" ? rec.instrumentId : null;
+  const name = typeof rec.name === "string" && rec.name.trim() ? rec.name : "Preset";
+  const values = (rec.values && typeof rec.values === "object" ? rec.values : {}) as Record<string, unknown>;
+  if (!instrumentId) return null;
+  const cleaned: Record<string, number> = {};
+  Object.entries(values).forEach(([key, val]) => {
+    if (typeof val === "number") cleaned[key] = clampMidi(val);
+  });
+  return { instrumentId, name, values: cleaned };
+}
+
+export function defaultStageRigState(): StageRigState {
+  return {
+    scenes: [],
+    macros: {},
+    instrumentPresets: {}
+  };
+}
+
+export function defaultStageState(): StageState {
+  return {
+    activeRigId: "default",
+    rigs: { default: defaultStageRigState() }
+  };
+}
+
+export function coerceStageState(raw: unknown, fallback: StageState = defaultStageState()): StageState {
+  if (!raw || typeof raw !== "object") return fallback;
+  const rec = raw as Record<string, unknown>;
+  const rigs = rec.rigs && typeof rec.rigs === "object" ? (rec.rigs as Record<string, unknown>) : {};
+  const activeRigId = typeof rec.activeRigId === "string" && rec.activeRigId.trim() ? rec.activeRigId : fallback.activeRigId;
+
+  const cleanedRigs: Record<string, StageRigState> = {};
+  Object.entries(rigs).forEach(([rigId, rigRaw], rigIdx) => {
+    const rigRec = rigRaw && typeof rigRaw === "object" ? (rigRaw as Record<string, unknown>) : {};
+    const scenesRaw = Array.isArray(rigRec.scenes) ? rigRec.scenes.slice(0, 64) : [];
+    const scenes = scenesRaw.map((s, sceneIdx) => coerceScene(s, sceneIdx));
+    const macrosRaw = rigRec.macros && typeof rigRec.macros === "object" ? (rigRec.macros as Record<string, unknown>) : {};
+    const macros: StageMacroValues = {};
+    Object.entries(macrosRaw).forEach(([key, val]) => {
+      if (typeof val === "number") macros[key] = clampMidi(val);
+    });
+
+    const presetsRaw = rigRec.instrumentPresets && typeof rigRec.instrumentPresets === "object"
+      ? (rigRec.instrumentPresets as Record<string, unknown>)
+      : {};
+    const instrumentPresets: Record<string, StageInstrumentPreset> = {};
+    Object.values(presetsRaw).forEach((presetRaw) => {
+      const preset = coercePreset(presetRaw);
+      if (preset) instrumentPresets[preset.instrumentId] = preset;
+    });
+
+    const rigKey = rigId || `rig-${rigIdx + 1}`;
+    cleanedRigs[rigKey] = { scenes, macros, instrumentPresets };
+  });
+
+  if (!cleanedRigs[activeRigId]) {
+    cleanedRigs[activeRigId] = fallback.rigs[activeRigId] ?? defaultStageRigState();
+  }
+
+  return { activeRigId, rigs: Object.keys(cleanedRigs).length ? cleanedRigs : fallback.rigs };
+}
+
+export type StageRigExport = {
+  rigId: string;
+  scenes: StageScene[];
+  macros: StageMacroValues;
+  instrumentPresets: StageInstrumentPreset[];
+};
+
+export function exportStageRig(state: StageState): StageRigExport {
+  const rig = state.rigs[state.activeRigId] ?? defaultStageRigState();
+  return {
+    rigId: state.activeRigId,
+    scenes: rig.scenes,
+    macros: rig.macros,
+    instrumentPresets: Object.values(rig.instrumentPresets)
+  };
+}
+
+export function importStageRig(state: StageState, preset: StageRigExport): StageState {
+  const next = coerceStageState(state);
+  const rigId = preset.rigId && preset.rigId.trim() ? preset.rigId : next.activeRigId;
+  const scenes = Array.isArray(preset.scenes) ? preset.scenes.map((s, idx) => coerceScene(s, idx)) : [];
+  const macros: StageMacroValues = {};
+  Object.entries(preset.macros ?? {}).forEach(([key, val]) => {
+    if (typeof val === "number") macros[key] = clampMidi(val);
+  });
+  const instrumentPresets: Record<string, StageInstrumentPreset> = {};
+  (preset.instrumentPresets ?? []).forEach((p) => {
+    const cleaned = coercePreset(p);
+    if (cleaned) instrumentPresets[cleaned.instrumentId] = cleaned;
+  });
+
+  return {
+    activeRigId: rigId,
+    rigs: {
+      ...next.rigs,
+      [rigId]: {
+        scenes,
+        macros,
+        instrumentPresets
+      }
+    }
+  };
+}

--- a/apps/desktop/src/app/StagePage.tsx
+++ b/apps/desktop/src/app/StagePage.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useRef, useState, type CSSProperties } from "react";
+import {
+  addScene,
+  exportActiveRig,
+  importRigFromFile,
+  removeInstrumentPreset,
+  removeScene,
+  resetStageSlice,
+  setActiveRig,
+  setMacro,
+  upsertInstrumentPreset,
+  updateScene
+} from "../store/stageSlice";
+import { defaultStageRigState, type StageRigExport, type StageState } from "../../shared/stageTypes";
+
+const macroLabels = ["M1", "M2", "M3", "M4", "M5", "M6", "M7", "M8"];
+
+export function StagePage({ stage, onChange }: { stage: StageState; onChange: (next: StageState) => void }) {
+  const rig = stage.rigs[stage.activeRigId] ?? defaultStageRigState();
+  const [newRigId, setNewRigId] = useState("");
+  const [newSceneName, setNewSceneName] = useState("New Scene");
+  const [newPresetInstrument, setNewPresetInstrument] = useState("synth-1");
+  const [newPresetName, setNewPresetName] = useState("Lead");
+  const [status, setStatus] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const macroValues = useMemo(() => {
+    return macroLabels.map((id) => ({ id, value: rig.macros[id] ?? 0 }));
+  }, [rig.macros]);
+
+  function handleExport() {
+    const payload = exportActiveRig(stage);
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${payload.rigId || "stage"}-preset.json`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+    setStatus(`Exported rig "${payload.rigId}" to download.`);
+  }
+
+  async function handleImport(file: File) {
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as StageRigExport;
+      onChange(importRigFromFile(stage, parsed));
+      setStatus(`Imported rig "${parsed.rigId || "default"}".`);
+    } catch (err) {
+      console.error("Failed to import stage preset", err);
+      setStatus("Import failed: invalid file");
+    } finally {
+      if (fileRef.current) fileRef.current.value = "";
+    }
+  }
+
+  function handleAddPreset() {
+    if (!newPresetInstrument.trim()) return;
+    onChange(
+      upsertInstrumentPreset(stage, {
+        instrumentId: newPresetInstrument.trim(),
+        name: newPresetName.trim() || "Preset",
+        values: { macro: 64 }
+      })
+    );
+    setStatus(`Preset saved for ${newPresetInstrument.trim()}`);
+  }
+
+  return (
+    <div style={styles.page}>
+      <div style={styles.headerRow}>
+        <div>
+          <div style={styles.muted}>Active rig</div>
+          <div style={styles.row}>
+            <select
+              value={stage.activeRigId}
+              onChange={(e) => onChange(setActiveRig(stage, e.target.value))}
+              style={styles.select}
+            >
+              {Object.keys(stage.rigs).map((rigId) => (
+                <option key={rigId}>{rigId}</option>
+              ))}
+            </select>
+            <input
+              style={styles.input}
+              value={newRigId}
+              placeholder="New rig id"
+              onChange={(e) => setNewRigId(e.target.value)}
+            />
+            <button style={styles.button} onClick={() => onChange(setActiveRig(stage, newRigId || "default"))}>
+              Set Rig
+            </button>
+            <button style={styles.secondary} onClick={() => onChange(resetStageSlice())}>
+              Reset Stage
+            </button>
+          </div>
+        </div>
+        <div style={styles.row}>
+          <button style={styles.secondary} onClick={() => fileRef.current?.click()}>
+            Import preset
+          </button>
+          <button style={styles.button} onClick={handleExport}>
+            Export preset
+          </button>
+          <input
+            type="file"
+            accept="application/json"
+            ref={fileRef}
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void handleImport(file);
+            }}
+          />
+        </div>
+      </div>
+
+      {status && <div style={styles.status}>{status}</div>}
+
+      <div style={styles.grid}>
+        <div style={styles.panel}>
+          <div style={styles.panelHeader}>
+            <h3 style={styles.panelTitle}>Scenes</h3>
+            <div style={styles.row}>
+              <input
+                style={styles.input}
+                value={newSceneName}
+                onChange={(e) => setNewSceneName(e.target.value)}
+              />
+              <button style={styles.button} onClick={() => onChange(addScene(stage, newSceneName))}>
+                Add
+              </button>
+            </div>
+          </div>
+          <div>
+            {rig.scenes.length === 0 && <div style={styles.muted}>No scenes yet.</div>}
+            {rig.scenes.map((scene) => (
+              <div key={scene.id} style={styles.listRow}>
+                <input
+                  style={styles.input}
+                  value={scene.name}
+                  onChange={(e) => onChange(updateScene(stage, scene.id, { name: e.target.value }))}
+                />
+                <button style={styles.secondary} onClick={() => onChange(removeScene(stage, scene.id))}>
+                  Delete
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div style={styles.panel}>
+          <div style={styles.panelHeader}>
+            <h3 style={styles.panelTitle}>Macros</h3>
+          </div>
+          <div>
+            {macroValues.map((macro) => (
+              <div key={macro.id} style={styles.macroRow}>
+                <span style={styles.muted}>{macro.id}</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={127}
+                  value={macro.value}
+                  onChange={(e) => onChange(setMacro(stage, macro.id, Number(e.target.value)))}
+                  style={{ flex: 1 }}
+                />
+                <span style={styles.valueLabel}>{macro.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div style={styles.panel}>
+        <div style={styles.panelHeader}>
+          <h3 style={styles.panelTitle}>Instrument presets</h3>
+          <div style={styles.row}>
+            <input
+              style={styles.input}
+              value={newPresetInstrument}
+              onChange={(e) => setNewPresetInstrument(e.target.value)}
+              placeholder="Instrument id"
+            />
+            <input
+              style={styles.input}
+              value={newPresetName}
+              onChange={(e) => setNewPresetName(e.target.value)}
+              placeholder="Preset name"
+            />
+            <button style={styles.button} onClick={handleAddPreset}>
+              Save preset
+            </button>
+          </div>
+        </div>
+        <div>
+          {Object.values(rig.instrumentPresets).length === 0 && <div style={styles.muted}>No presets captured.</div>}
+          {Object.values(rig.instrumentPresets).map((preset) => (
+            <div key={preset.instrumentId} style={styles.listRow}>
+              <div>
+                <strong>{preset.instrumentId}</strong>
+                <div style={styles.muted}>{preset.name}</div>
+              </div>
+              <button style={styles.secondary} onClick={() => onChange(removeInstrumentPreset(stage, preset.instrumentId))}>
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  page: { display: "flex", flexDirection: "column", gap: 16 },
+  headerRow: { display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-end" },
+  row: { display: "flex", alignItems: "center", gap: 8 },
+  grid: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 },
+  panel: { background: "#111827", padding: 12, borderRadius: 8, border: "1px solid #1f2937" },
+  panelHeader: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
+  panelTitle: { margin: 0, fontSize: 16, fontWeight: 500 },
+  input: {
+    background: "#0b1323",
+    border: "1px solid #1f2937",
+    borderRadius: 6,
+    padding: "8px 10px",
+    color: "#e5e7eb",
+    minWidth: 140
+  },
+  select: {
+    background: "#0b1323",
+    border: "1px solid #1f2937",
+    borderRadius: 6,
+    padding: "8px 10px",
+    color: "#e5e7eb"
+  },
+  button: {
+    background: "#0ea5e9",
+    border: "none",
+    color: "#0b1021",
+    borderRadius: 6,
+    padding: "8px 12px",
+    fontWeight: 600,
+    cursor: "pointer"
+  },
+  secondary: {
+    background: "#1f2937",
+    border: "1px solid #27324a",
+    color: "#e5e7eb",
+    borderRadius: 6,
+    padding: "8px 12px",
+    cursor: "pointer"
+  },
+  muted: { color: "#9ca3af", fontSize: 12 },
+  status: {
+    background: "#0b1323",
+    border: "1px solid #1f2937",
+    color: "#c7d2fe",
+    padding: 10,
+    borderRadius: 8
+  },
+  listRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 8,
+    padding: "8px 0",
+    borderBottom: "1px solid #1f2937"
+  },
+  macroRow: { display: "flex", alignItems: "center", gap: 8, padding: "6px 0" },
+  valueLabel: { width: 28, textAlign: "right", color: "#e5e7eb" }
+};

--- a/apps/desktop/src/store/stageSlice.ts
+++ b/apps/desktop/src/store/stageSlice.ts
@@ -1,0 +1,146 @@
+import {
+  coerceStageState,
+  defaultStageRigState,
+  defaultStageState,
+  exportStageRig,
+  importStageRig,
+  type StageInstrumentPreset,
+  type StageRigExport,
+  type StageScene,
+  type StageState
+} from "../../shared/stageTypes";
+
+function ensureRig(state: StageState, rigId?: string): StageState {
+  const targetRigId = rigId && rigId.trim() ? rigId : state.activeRigId;
+  if (state.rigs[targetRigId]) return state;
+  return {
+    ...state,
+    rigs: {
+      ...state.rigs,
+      [targetRigId]: defaultStageRigState()
+    }
+  };
+}
+
+export function setActiveRig(state: StageState, rigId: string): StageState {
+  const next = ensureRig(state, rigId);
+  return { ...next, activeRigId: rigId.trim() || next.activeRigId };
+}
+
+export function addScene(state: StageState, name?: string): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  const scene: StageScene = {
+    id: `scene-${Date.now().toString(36)}`,
+    name: name?.trim() || `Scene ${rig.scenes.length + 1}`
+  };
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        scenes: [...rig.scenes, scene]
+      }
+    }
+  };
+}
+
+export function updateScene(state: StageState, sceneId: string, partial: Partial<StageScene>): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        scenes: rig.scenes.map((scene) => (scene.id === sceneId ? { ...scene, ...partial } : scene))
+      }
+    }
+  };
+}
+
+export function removeScene(state: StageState, sceneId: string): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        scenes: rig.scenes.filter((scene) => scene.id !== sceneId)
+      }
+    }
+  };
+}
+
+export function setMacro(state: StageState, macroId: string, value: number): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  const nextValue = Math.min(127, Math.max(0, Math.round(value)));
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        macros: {
+          ...rig.macros,
+          [macroId]: nextValue
+        }
+      }
+    }
+  };
+}
+
+export function upsertInstrumentPreset(state: StageState, preset: StageInstrumentPreset): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        instrumentPresets: {
+          ...rig.instrumentPresets,
+          [preset.instrumentId]: preset
+        }
+      }
+    }
+  };
+}
+
+export function removeInstrumentPreset(state: StageState, instrumentId: string): StageState {
+  const prepared = ensureRig(state);
+  const rig = prepared.rigs[prepared.activeRigId] ?? defaultStageRigState();
+  const { [instrumentId]: _removed, ...rest } = rig.instrumentPresets;
+  return {
+    ...prepared,
+    rigs: {
+      ...prepared.rigs,
+      [prepared.activeRigId]: {
+        ...rig,
+        instrumentPresets: rest
+      }
+    }
+  };
+}
+
+export function importRigFromFile(state: StageState, payload: StageRigExport): StageState {
+  return importStageRig(state, payload);
+}
+
+export function exportActiveRig(state: StageState): StageRigExport {
+  return exportStageRig(state);
+}
+
+export function coerceStageSlice(raw: unknown): StageState {
+  return coerceStageState(raw, defaultStageState());
+}
+
+export function resetStageSlice(): StageState {
+  return defaultStageState();
+}


### PR DESCRIPTION
## Summary
- add stage data types and slice to manage rig-specific scenes, macros, and instrument presets
- persist stage state in project serialization and expose a Stage page with rig controls
- support importing and exporting stage presets for backup and sharing

## Testing
- npm run lint --prefix apps/desktop *(fails: existing TypeScript errors in App.tsx and ControlLabPage.tsx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ecf78b688331add5eb39d5b77f0e)