### PR TITLE
Add multi-target mapping slots with broadcast support

### DIFF
--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -1245,22 +1245,19 @@ export function App() {
   async function sendSnapshotNow() {
     if (!midiApi) return;
     const batches: { portId: string; msg: MidiMsg }[] = [];
-    devices.forEach((device) => {
-      if (!device.outputId) return;
-      controls.forEach((control) => {
-        control.slots.forEach((slot) => {
-          if (!slot?.enabled || slot.kind !== "cc") return;
-          const normalized = withTargetDefaults(slot);
-          const slotTargets = resolveSlotTargets(normalized, devices);
-          slotTargets.forEach(({ device: targetDevice, target }) => {
-            if (!targetDevice.outputId) return;
-            const channel = clampChannel(target?.channel ?? normalized.channel ?? targetDevice.channel);
-            const cc = clampMidi(target?.cc ?? normalized.cc ?? 0);
-            const value = clampMidi(normalized.max ?? 127);
-            batches.push({
-              portId: targetDevice.outputId,
-              msg: { t: "cc", ch: channel, cc, val: value }
-            });
+    controls.forEach((control) => {
+      control.slots.forEach((slot) => {
+        if (!slot?.enabled || slot.kind !== "cc") return;
+        const normalized = withTargetDefaults(slot);
+        const slotTargets = resolveSlotTargets(normalized, devices);
+        slotTargets.forEach(({ device: targetDevice, target }) => {
+          if (!targetDevice.outputId) return;
+          const channel = clampChannel(target?.channel ?? normalized.channel ?? targetDevice.channel);
+          const cc = clampMidi(target?.cc ?? normalized.cc ?? 0);
+          const value = clampMidi(normalized.max ?? 127);
+          batches.push({
+            portId: targetDevice.outputId,
+            msg: { t: "cc", ch: channel, cc, val: value }
           });
         });
       });

--- a/apps/desktop/src/app/SurfaceBoardPage.tsx
+++ b/apps/desktop/src/app/SurfaceBoardPage.tsx
@@ -94,13 +94,18 @@ function BindingList({ control }: { control: ControlElement }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
       {bindings.map((slot, idx) => {
+        const targetLabel = slot.broadcast
+          ? "Broadcast"
+          : slot.targets?.length
+            ? slot.targets.map((t) => t.deviceId).join(", ")
+            : slot.targetDeviceId ?? "no target";
         if (slot.kind === "cc") {
           return (
             <BindingRow
               key={idx}
               label={`CC ${slot.cc}`}
               detail={`ch ${slot.channel ?? "dev"} / ${slot.min}-${slot.max} / ${slot.curve}`}
-              target={slot.targetDeviceId}
+              target={targetLabel}
             />
           );
         }
@@ -110,7 +115,7 @@ function BindingList({ control }: { control: ControlElement }) {
               key={idx}
               label={`Program`}
               detail={`ch ${slot.channel ?? "dev"} / ${slot.min}-${slot.max} / ${slot.curve}`}
-              target={slot.targetDeviceId}
+              target={targetLabel}
             />
           );
         }
@@ -120,7 +125,7 @@ function BindingList({ control }: { control: ControlElement }) {
               key={idx}
               label={`Note ${slot.note}`}
               detail={`ch ${slot.channel ?? "dev"} / vel ${slot.vel}`}
-              target={slot.targetDeviceId}
+              target={targetLabel}
             />
           );
         }

--- a/packages/core/src/mapping/engine.ts
+++ b/packages/core/src/mapping/engine.ts
@@ -1,6 +1,6 @@
 import type { MidiMsg } from "../midi/types";
 import { applyCurve01, clamp01 } from "./curves";
-import type { ControlElement, MappingSlot } from "./types";
+import type { ControlElement, MappingSlot, MappingSlotTarget } from "./types";
 
 export type MappingDeviceTarget = {
   id: string;
@@ -13,6 +13,35 @@ export type MidiSend = {
   msg: MidiMsg;
 };
 
+export type SlotTargetContext = {
+  device: MappingDeviceTarget;
+  target: MappingSlotTarget | null;
+};
+
+export function resolveSlotTargets(slot: MappingSlot, devices: MappingDeviceTarget[]): SlotTargetContext[] {
+  if (slot.broadcast) {
+    return devices.map((device) => ({ device, target: null }));
+  }
+
+  const explicitTargets = (slot.targets ?? []).map((t) => ({
+    device: devices.find((d) => d.id === t.deviceId),
+    target: t
+  }));
+
+  if (explicitTargets.some((t) => t.device)) {
+    return explicitTargets.filter((t): t is { device: MappingDeviceTarget; target: MappingSlotTarget } => Boolean(t.device));
+  }
+
+  if (slot.targetDeviceId) {
+    const device = devices.find((d) => d.id === slot.targetDeviceId);
+    if (device) {
+      return [{ device, target: null }];
+    }
+  }
+
+  return [];
+}
+
 export function computeMappingSends(control: ControlElement, value: number, devices: MappingDeviceTarget[]): MidiSend[] {
   const value01 = clamp01(value / 127);
   const results: MidiSend[] = [];
@@ -20,45 +49,48 @@ export function computeMappingSends(control: ControlElement, value: number, devi
   for (const slot of control.slots) {
     if (!slot.enabled) continue;
     if (slot.kind === "empty") continue;
-    if (!slot.targetDeviceId) continue;
+    const slotTargets = resolveSlotTargets(slot, devices);
+    if (!slotTargets.length) continue;
 
-    const device = devices.find((d) => d.id === slot.targetDeviceId);
-    if (!device?.outputId) continue;
-    const channel = clampChannel(slot.channel ?? device.channel);
+    for (const { device, target } of slotTargets) {
+      if (!device.outputId) continue;
+      const channel = clampChannel(target?.channel ?? slot.channel ?? device.channel);
 
-    if (slot.kind === "cc") {
-      const shaped01 = applyCurve01(value01, slot.curve);
-      const min = clampMidi(slot.min);
-      const max = clampMidi(slot.max);
-      const mapped = Math.round(min + shaped01 * (max - min));
-      results.push({
-        portId: device.outputId,
-        msg: { t: "cc", ch: channel, cc: clampMidi(slot.cc), val: clampMidi(mapped) }
-      });
-    } else if (slot.kind === "pc") {
-      const shaped01 = applyCurve01(value01, slot.curve);
-      const min = clampMidi(slot.min);
-      const max = clampMidi(slot.max);
-      const program = clampMidi(Math.round(min + shaped01 * (max - min)));
-      results.push({
-        portId: device.outputId,
-        msg: { t: "programChange", ch: channel, program }
-      });
-    } else if (slot.kind === "note") {
-      const note = clampMidi(slot.note);
-      if (value <= 0) {
+      if (slot.kind === "cc") {
+        const shaped01 = applyCurve01(value01, slot.curve);
+        const min = clampMidi(slot.min);
+        const max = clampMidi(slot.max);
+        const mapped = Math.round(min + shaped01 * (max - min));
+        const cc = clampMidi(target?.cc ?? slot.cc);
         results.push({
           portId: device.outputId,
-          msg: { t: "noteOff", ch: channel, note, vel: 0 }
+          msg: { t: "cc", ch: channel, cc, val: clampMidi(mapped) }
         });
+      } else if (slot.kind === "pc") {
+        const shaped01 = applyCurve01(value01, slot.curve);
+        const min = clampMidi(slot.min);
+        const max = clampMidi(slot.max);
+        const program = clampMidi(Math.round(min + shaped01 * (max - min)));
+        results.push({
+          portId: device.outputId,
+          msg: { t: "programChange", ch: channel, program }
+        });
+      } else if (slot.kind === "note") {
+        const note = clampMidi(slot.note);
+        if (value <= 0) {
+          results.push({
+            portId: device.outputId,
+            msg: { t: "noteOff", ch: channel, note, vel: 0 }
+          });
+        } else {
+          results.push({
+            portId: device.outputId,
+            msg: { t: "noteOn", ch: channel, note, vel: clampMidi(slot.vel) }
+          });
+        }
       } else {
-        results.push({
-          portId: device.outputId,
-          msg: { t: "noteOn", ch: channel, note, vel: clampMidi(slot.vel) }
-        });
+        assertNever(slot);
       }
-    } else {
-      assertNever(slot);
     }
   }
 

--- a/packages/core/src/mapping/types.ts
+++ b/packages/core/src/mapping/types.ts
@@ -1,37 +1,43 @@
 export type Curve = "linear" | "expo" | "log";
 
+export type MappingSlotTarget = {
+  deviceId: string;
+  channel?: number;
+  cc?: number;
+};
+
+type MappingSlotBase = {
+  enabled: boolean;
+  broadcast?: boolean;
+  targets?: MappingSlotTarget[];
+  targetDeviceId?: string | null;
+};
+
 export type MappingSlot =
-  | {
-      enabled: boolean;
+  | (MappingSlotBase & {
       kind: "cc";
       cc: number;
       channel?: number;
       min: number;
       max: number;
       curve: Curve;
-      targetDeviceId: string | null;
-    }
-  | {
-      enabled: boolean;
+    })
+  | (MappingSlotBase & {
       kind: "pc";
       channel?: number;
       min: number;
       max: number;
       curve: Curve;
-      targetDeviceId: string | null;
-    }
-  | {
-      enabled: boolean;
+    })
+  | (MappingSlotBase & {
       kind: "note";
       note: number;
       channel?: number;
       vel: number;
-      targetDeviceId: string | null;
-    }
-  | {
-      enabled: boolean;
+    })
+  | (MappingSlotBase & {
       kind: "empty";
-    };
+    });
 
 export type ControlElementType = "knob" | "fader" | "button";
 
@@ -44,5 +50,11 @@ export type ControlElement = {
 };
 
 export function defaultSlots(): MappingSlot[] {
-  return Array.from({ length: 8 }, () => ({ enabled: false, kind: "empty" } as const));
+  return Array.from({ length: 8 }, () => ({
+    enabled: false,
+    kind: "empty",
+    targets: [],
+    broadcast: false,
+    targetDeviceId: null
+  } as const));
 }


### PR DESCRIPTION
## Summary
- allow mapping slots to hold multiple targets or broadcast and update mapping send computation
- persist the expanded mapping slot schema when loading projects
- update the mapping UI and snapshot send logic to edit and honor per-target overrides

## Testing
- pnpm -C packages/core test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945eb9a1bb48331aa2ea115a45c9c32)